### PR TITLE
Replace FsEventWatcher with cross-platform RecommendedWatcher

### DIFF
--- a/src/lsp/change_notifier.rs
+++ b/src/lsp/change_notifier.rs
@@ -14,7 +14,7 @@ use crate::project::Project;
 #[derive(Debug)]
 pub struct ChangeNotifier {
     #[allow(dead_code)] // Keep the handle to ensure the change notifier runs
-    debouncer: Debouncer<FsEventWatcher>,
+    debouncer: Debouncer<RecommendedWatcher>,
 }
 
 impl ChangeNotifier {


### PR DESCRIPTION
Using FsEventWatcher results in a compiler error on Linux.
This PR replaces FsEventWatcher with [RecommendedWatcher](https://docs.rs/notify/latest/src/notify/lib.rs.html#346).