### PR TITLE
Updated create_mcp_configuration_file to create the parent directory

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -504,8 +504,15 @@ fn find_root_project(mut path: &Path, projects: &[ProjectDescription]) -> Option
 }
 
 fn create_mcp_configuration_file(path: &Path, contents: String) -> anyhow::Result<()> {
-    let config_path = PathBuf::from(path).join(".cursor/mcp.json");
-    std::fs::create_dir_all(&config_path)?;
-    std::fs::write(config_path, contents)?;
+    let config_dir = PathBuf::from(path).join(".cursor");
+    let config_path = config_dir.join("mcp.json");
+    if let Err(e) = std::fs::create_dir_all(&config_dir) {
+        tracing::error!("Failed to create directory {:?}. Error: {}", config_dir, e);
+        return Err(e.into());
+    }
+    if let Err(e) = std::fs::write(&config_path, &contents) {
+        tracing::error!("Failed to write mcp.json at {:?} with contents: {}. Error: {}", config_path, contents, e);
+        return Err(e.into());
+    }
     Ok(())
 }


### PR DESCRIPTION
it used to create a directory called mcp.json and then obviously fail to write the config to a file where that directory was already